### PR TITLE
Derive correct child key if input buffer is ArrayBuffer

### DIFF
--- a/src/hd-key.js
+++ b/src/hd-key.js
@@ -45,7 +45,7 @@ export function deriveChild ({ privateKey, chainCode }, index) {
     Buffer.from(indexBuffer)
   ])
 
-  const I = hmac(data, chainCode)
+  const I = hmac(data, Buffer.from(chainCode))
   const IL = I.slice(0, 32)
   const IR = I.slice(32)
   return {

--- a/test/hd-key.js
+++ b/test/hd-key.js
@@ -45,11 +45,21 @@ describe('hd-key', () => {
       expect(masterKey).to.eql(testMasterKey)
     }))
 
-  describe('deriveChild', () =>
+  describe('deriveChild', () => {
     it('derives correct child key', () => {
       const childKey = deriveChild(testMasterKey, testChildIndex)
       expect(childKey).to.eql(testChildKey)
-    }))
+    })
+
+    it('derives correct child key if input buffer is ArrayBuffer', () => {
+      const arrayBufferMasterKey = {
+        privateKey: new Uint8Array(testMasterKey.privateKey).buffer,
+        chainCode: new Uint8Array(testMasterKey.chainCode).buffer
+      }
+      const arrayBufferChildKey = deriveChild(arrayBufferMasterKey, testChildIndex)
+      expect(arrayBufferChildKey).to.eql(testChildKey)
+    })
+  })
 
   describe('derivePathFromKey', () =>
     it('derives correct child key by path and key', () => {


### PR DESCRIPTION
`full` function from `tweetnacl-auth` package returns a completely different result if the passed value has `ArrayBuffer` type instead of `Uint8Array` or `Buffer` (in nodejs).
This patch fixes it by explicit converting of `full` arguments to `Buffer` type.