### PR TITLE
method to derive wallet with custom derivation path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /.envrc
 /yarn-error.log
 .idea
+.vscode

--- a/src/hd-wallet.js
+++ b/src/hd-wallet.js
@@ -21,6 +21,10 @@ export function generateHDWallet (seed) {
   return derivePathFromSeed('m/44h/457h', seed)
 }
 
+export function generateWalletUsingDerivationPath (seed, derivationPath = 'm/44h/457h/0h/0h/0h') {
+  return getKeyPair(derivePathFromSeed(derivationPath, seed).privateKey)
+}
+
 export function getHDWalletAccounts (wallet, accountCount) {
   return (new Array(accountCount)).fill()
     .map((_, idx) =>


### PR DESCRIPTION
We added a method to derive a wallet using a custom derivation path for use in our [airgap-coin-lib](https://github.com/airgap-it/airgap-coin-lib) & [airgap-vault](https://github.com/airgap-it/airgap-vault).

As we have some troubles with NPM installing packages over GitHub / Git (they sometimes do not get installed if they are a sub-dependency), we'd be happy if you merge this and publish to NPM.

Let me know if I should make any changes on the added method.