### PR TITLE
Fix incorrect GitHub URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/aeternity/wallet-js"
+    "url": "https://github.com/aeternity/hd-wallet-js"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0-beta.46",


### PR DESCRIPTION
The link on npmjs.com is broken. I assume this is what would fix it?

I don't know the NPM world very well